### PR TITLE
refactor: 프로필 이미지 리사이징  로직 수정

### DIFF
--- a/src/main/java/com/moyeota/moyeotaproject/controller/UsersController.java
+++ b/src/main/java/com/moyeota/moyeotaproject/controller/UsersController.java
@@ -62,11 +62,11 @@ public class UsersController {
 	private final SchoolService schoolService;
 	private final ImageService imageService;
 
-	@ApiOperation(value = "프로필 이미지 사이즈 조정", notes = "프로필 이미지 사이즈를 86 * 86으로 조정")
-	@GetMapping("/image-resizing")
-	public ResponseDto<String> getImage(@RequestParam("imageUrl") String imageUrl) {
-		return ResponseUtil.SUCCESS("이미지 사이즈 조정에 성공하였습니다.", imageService.getResizedImageUrl(imageUrl));
-	}
+	// @ApiOperation(value = "프로필 이미지 사이즈 조정", notes = "프로필 이미지 사이즈를 86 * 86으로 조정")
+	// @GetMapping("/image-resizing")
+	// public ResponseDto<String> getImage(@RequestParam("imageUrl") String imageUrl) {
+	// 	return ResponseUtil.SUCCESS("이미지 사이즈 조정에 성공하였습니다.", imageService.getResizedImageUrl(imageUrl));
+	// }
 
 	@ApiOperation(value = "사용자 정보 조회", notes = "사용자 정보 API")
 	@GetMapping

--- a/src/main/java/com/moyeota/moyeotaproject/service/OAuthLoginService.java
+++ b/src/main/java/com/moyeota/moyeotaproject/service/OAuthLoginService.java
@@ -88,7 +88,8 @@ public class OAuthLoginService {
 		if (oAuthInfoResponse.getProfileImage().equals(KAKAO_DEFAULT_IMAGE)) {
 			return imageService.defaultProfileImage();
 		}
-		return oAuthInfoResponse.getProfileImage();
+
+		return imageService.getResizedImageUrl(oAuthInfoResponse.getProfileImage());
 	}
 
 	private OAuth createOAuthFromOAuthInfo(Users user, OAuthInfoResponse oAuthInfoResponse) {


### PR DESCRIPTION
기존
회원가입 후, 프론트에서 프로필 이미지 리사이징 api 호출

변경
회원가입 시 카카오 프로필 이미지 얻는 동시에 리사이징 진행
UserController getImage 메서드 제거
OAuthLoginService getProfileImage 메서드 수정