### PR TITLE
fix: Service 순환 참조 문제 해결

### DIFF
--- a/src/main/java/com/moyeota/moyeotaproject/controller/ParticipationDetailsController.java
+++ b/src/main/java/com/moyeota/moyeotaproject/controller/ParticipationDetailsController.java
@@ -53,7 +53,7 @@ public class ParticipationDetailsController {
 	@PostMapping("/cancellation/posts/{postId}") //유저 인증 먼저 하기
 	public ResponseDto<Long> cancel(HttpServletRequest request,
 		@ApiParam(value = "참가내역 인덱스 번호") @PathVariable("postId") Long postId) {
-		participationDetailsService.cancelParticipation(postId, request.getHeader("Authorization"));
+		participationDetailsService.cancelParticipation(postId, request.getHeader("Authorization"), postsService);
 		return ResponseUtil.SUCCESS("참가 취소가 완료되었습니다.", postId);
 	}
 

--- a/src/main/java/com/moyeota/moyeotaproject/service/ParticipationDetailsService.java
+++ b/src/main/java/com/moyeota/moyeotaproject/service/ParticipationDetailsService.java
@@ -34,7 +34,6 @@ public class ParticipationDetailsService {
 	private final UsersRepository usersRepository;
 	private final PostsRepository postsRepository;
 	private final ParticipationDetailsRepository participationDetailsRepository;
-	private final PostsService postsService;
 
 	public Long join(String accessToken, Long postId) {
 		Users user = usersService.getUserByToken(accessToken);
@@ -116,7 +115,7 @@ public class ParticipationDetailsService {
 
 	}
 
-	public boolean cancelParticipation(Long postId, String accessToken) {
+	public boolean cancelParticipation(Long postId, String accessToken, PostsService postsService) {
 		Users user = usersService.getUserByToken(accessToken);
 		Posts post = postsRepository.findById(postId).orElseThrow(()
 			-> new IllegalArgumentException("해당 모집글이 없습니다. id=" + postId));

--- a/src/main/java/com/moyeota/moyeotaproject/service/PostsService.java
+++ b/src/main/java/com/moyeota/moyeotaproject/service/PostsService.java
@@ -29,8 +29,8 @@ import com.moyeota.moyeotaproject.domain.totaldetail.TotalDetailRepository;
 import com.moyeota.moyeotaproject.domain.users.Users;
 import com.moyeota.moyeotaproject.domain.users.UsersRepository;
 import com.moyeota.moyeotaproject.dto.postsdto.MembersLocationResponseDto;
-import com.moyeota.moyeotaproject.dto.postsdto.PostsResponseDto;
 import com.moyeota.moyeotaproject.dto.postsdto.PostsMemberDto;
+import com.moyeota.moyeotaproject.dto.postsdto.PostsResponseDto;
 import com.moyeota.moyeotaproject.dto.postsdto.PostsSaveRequestDto;
 import com.moyeota.moyeotaproject.dto.postsdto.PostsUpdateRequestDto;
 


### PR DESCRIPTION
ParticipationDetailsService와 PostsService 간의 순환 참조 문제 발생 ParticipationDetailsService의 cancelParticipation method에서 PostsService를 메소드주입 방식으로 변경하여 해결